### PR TITLE
add fort forinthry bonus xp

### DIFF
--- a/dailyscape.js
+++ b/dailyscape.js
@@ -311,6 +311,7 @@ var rs3weekly = {
     "dream-of-iaia-resource": {task: "Dream of Iaia Resources", url: "https://runescape.wiki/w/Dream_of_Iaia", desc: "Convert resources to skilling stations at a rate of 2 resource to 1 xp"},
     "gwd2-bounties": {task: "GWD2 Bounties", url: "https://runescape.wiki/w/Feng,_the_Bounty_Master", desc: "Up to 5 bounties can be stored for GWD2 reputation"},
     "dnd-of-the-week": {task: "D&amp;D of the Week", url: "https://runescape.wiki/w/Distractions_and_Diversions#D&D_of_the_week", desc:"Participate for a TH key token:<span id=\"dnd-of-the-week\"></span>"},
+    "fort-forinthry-bonus-xp": {task: "Fort Forinthry Bonus XP", url: "https://runescape.wiki/w/Town_Hall_(Fort_Forinthry)", desc:"Receive up to 15 small stars worth of bonus xp"},
 };
 
 var rs3monthly = {


### PR DESCRIPTION
Additional weekly for rested xp from Fort Forinthry (about 15 small lamps per 2 weeks purely afk -- more often for active skilling inside the forth)